### PR TITLE
Potential fix for code scanning alert no. 102: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/test/-ext-/string/test_capacity.rb
+++ b/test/-ext-/string/test_capacity.rb
@@ -31,9 +31,9 @@ class Test_StringCapacity < Test::Unit::TestCase
 
   def test_io_read
     s = String.new(capacity: 1000)
-    open(__FILE__) {|f|f.read(1024*1024, s)}
+    File.open(__FILE__) {|f|f.read(1024*1024, s)}
     assert_equal(1024*1024, capa(s))
-    open(__FILE__) {|f|s = f.read(1024*1024)}
+    File.open(__FILE__) {|f|s = f.read(1024*1024)}
     assert_operator(capa(s), :<=, s.bytesize+4096)
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/Milanhe92/AI-alati/security/code-scanning/102](https://github.com/Milanhe92/AI-alati/security/code-scanning/102)

To fix the problem, we need to replace the `Kernel.open` method with `File.open`. This change will ensure that the code does not have the vulnerability associated with `Kernel.open`. The functionality of the code will remain the same, as `File.open` can be used in the same way to read the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
