### PR TITLE
Potential fix for code scanning alert no. 102: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

Co-authored-by: Copilot Autofix powered by AI <62310815+github-advanced-security[bot]@users.noreply.github.com>
Signed-off-by: Milan He <179525809+Milanhe92@users.noreply.github.com>

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {}
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/workflows/WIKI
+++ b/.github/workflows/WIKI
@@ -1,0 +1,1 @@
+https://github.com/Milanhe92/AI-alati.wiki.git

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/test/-ext-/string/test_capacity.rb
+++ b/test/-ext-/string/test_capacity.rb
@@ -31,9 +31,9 @@ class Test_StringCapacity < Test::Unit::TestCase
 
   def test_io_read
     s = String.new(capacity: 1000)
-    open(__FILE__) {|f|f.read(1024*1024, s)}
+    File.open(__FILE__) {|f|f.read(1024*1024, s)}
     assert_equal(1024*1024, capa(s))
-    open(__FILE__) {|f|s = f.read(1024*1024)}
+    File.open(__FILE__) {|f|s = f.read(1024*1024)}
     assert_operator(capa(s), :<=, s.bytesize+4096)
   end
 


### PR DESCRIPTION
*Continuous improvement 